### PR TITLE
Fix Eloquent\Builder::where to pass along AND/OR

### DIFF
--- a/src/Database/Eloquent/Builder.php
+++ b/src/Database/Eloquent/Builder.php
@@ -143,7 +143,7 @@ class Builder
             $this->query->where(function (QueryBuilder $queryBuilder) use ($column) {
                 $eloquentBuilder = $this->model->newEloquentBuilder($queryBuilder);
                 $column($eloquentBuilder);
-            });
+            }, null, null, $boolean);
         } else {
             $this->query->where(...func_get_args());
         }


### PR DESCRIPTION
When using `Eloquent\Builder::orWhere` with a `Closure`, the generated query would connect the clauses with `AND`.

Fix this by passing the `$boolean` connective through to the base query builder.