### PR TITLE
Suppress deprecation warning

### DIFF
--- a/src/Database/Eloquent/Model.php
+++ b/src/Database/Eloquent/Model.php
@@ -641,6 +641,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getAttribute($offset);


### PR DESCRIPTION
WARNING: Return type of Bavix\LaravelClickHouse\Database\Eloquent\Model::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice